### PR TITLE
Control integration

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,4 +34,5 @@ jobs:
                 ]
               }
             }
+          vcs-repo-file-url: https://raw.githubusercontent.com/MOCAP4ROS2-Project/mocap4ros2_gazebo/main/dependency_repos.repos
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(gazebo_msgs REQUIRED)
 find_package(gazebo_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(mocap_msgs REQUIRED)
+find_package(mocap_control REQUIRED)
 find_package(rclcpp REQUIRED)
 
 link_directories(${gazebo_dev_LIBRARY_DIRS})
@@ -53,6 +54,7 @@ ament_target_dependencies(gazebo_ros_mocap
   "gazebo_ros"
   "rclcpp"
   "mocap_msgs"
+  "mocap_control"
   "geometry_msgs"
 )
 ament_export_libraries(gazebo_ros_mocap)
@@ -64,6 +66,7 @@ ament_export_dependencies(gazebo_dev)
 ament_export_dependencies(gazebo_msgs)
 ament_export_dependencies(gazebo_ros)
 ament_export_dependencies(mocap_msgs)
+ament_export_dependencies(mocap_control)
 ament_export_dependencies(geometry_msgs)
 
 if(BUILD_TESTING)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ And check that topics `/markers` and `/rigid_bodies` are availables
 
 Example of full integration with `mocap_control`.
 
-[![](https://img.youtube.com/vi/ex3eQ328NDU/0.jpg)](https://www.youtube.com/watch?v=ex3eQ328NDU&feature=youtu.be "Click to play on You Tube")
+[![](https://img.youtube.com/vi/i9U_T0Ti6Oo/0.jpg)](https://www.youtube.com/watch?v=i9U_T0Ti6Oo&feature=youtu.be "Click to play on You Tube")
 
 
 ## Markers and rigid body

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ gzclient
 
 And check that topics `/markers` and `/rigid_bodies` are availables
 
+
+Example of full integration with `mocap_control`.
+
+[![](https://img.youtube.com/vi/ex3eQ328NDU/0.jpg)](https://www.youtube.com/watch?v=ex3eQ328NDU&feature=youtu.be "Click to play on You Tube")
+
+
 ## Markers and rigid body
 <img src="https://user-images.githubusercontent.com/3810011/178335627-080f8d5a-7b6f-40d2-8038-caf73e7cf8d9.png" width="500">
 <img src="https://user-images.githubusercontent.com/3810011/178335622-02e126f7-ec96-41a0-9936-38af589c5a2d.png" width="500">

--- a/dependency_repos.repos
+++ b/dependency_repos.repos
@@ -1,0 +1,9 @@
+repositories:
+  mocap_msgs:
+    type: git
+    url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+    version: main
+  mocap:
+    type: git
+    url: https://github.com/MOCAP4ROS2-Project/mocap.git
+    version: main

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>geometry_msgs</depend>
   <depend>mocap_msgs</depend>
+  <depend>mocap_control</depend>
   <depend>gazebo_dev</depend>
   <depend>gazebo_msgs</depend>
   <depend>gazebo_ros</depend>

--- a/src/gazebo_ros_mocap.cpp
+++ b/src/gazebo_ros_mocap.cpp
@@ -166,16 +166,16 @@ void GazeboRosMocap::OnUpdate()
     m1.translation.z = pos.Z() + 0.05;
 
     mocap_msgs::msg::Marker m2;
-    m1.index = 2;
-    m1.translation.x = pos.X() + 0.02;
-    m1.translation.y = pos.Y();
-    m1.translation.z = pos.Z() + 0.03;
+    m2.index = 2;
+    m2.translation.x = pos.X() + 0.02;
+    m2.translation.y = pos.Y();
+    m2.translation.z = pos.Z() + 0.03;
 
     mocap_msgs::msg::Marker m3;
-    m1.index = 3;
-    m1.translation.x = pos.X();
-    m1.translation.y = pos.Y() + 0.015;
-    m1.translation.z = pos.Z() + 0.03;
+    m3.index = 3;
+    m3.translation.x = pos.X();
+    m3.translation.y = pos.Y() + 0.015;
+    m3.translation.z = pos.Z() + 0.03;
 
     mocap_msgs::msg::Markers ms;
     ms.header.stamp = impl_->now();

--- a/src/gazebo_ros_mocap.cpp
+++ b/src/gazebo_ros_mocap.cpp
@@ -23,21 +23,31 @@
 
 #include "mocap_msgs/msg/markers.hpp"
 #include "mocap_msgs/msg/rigid_body.hpp"
-
+#include "lifecycle_msgs/msg/state.hpp"
 
 #include "rclcpp/rclcpp.hpp"
-
+#include "mocap_control/ControlledLifecycleNode.hpp"
 
 namespace gazebo
 {
 
 GZ_REGISTER_MODEL_PLUGIN(GazeboRosMocap)
 
+using CallbackReturnT =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
 /// Class to hold private data members (PIMPL pattern)
-class GazeboRosMocapPrivate
+class GazeboRosMocapPrivate : public mocap_control::ControlledLifecycleNode
 {
 public:
-  GazeboRosMocapPrivate() {}
+  GazeboRosMocapPrivate();
+
+  CallbackReturnT on_configure(const rclcpp_lifecycle::State & state) override;
+  CallbackReturnT on_activate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturnT on_deactivate(const rclcpp_lifecycle::State & state) override;
+
+  void control_start(const mocap_control_msgs::msg::Control::SharedPtr msg) override;
+  void control_stop(const mocap_control_msgs::msg::Control::SharedPtr msg) override;
 
   /// Connection to world update event. Callback is called while this is alive.
   gazebo::event::ConnectionPtr update_connection_;
@@ -45,12 +55,63 @@ public:
   physics::LinkPtr link_;
   std::string link_name_;
 
-  /// Node for ROS communication.
-  rclcpp::Node::SharedPtr ros_node_;
-  rclcpp::Publisher<mocap_msgs::msg::Markers>::SharedPtr mocap_markers_pub_;
-  rclcpp::Publisher<mocap_msgs::msg::RigidBody>::SharedPtr mocap_rigid_body_pub_;
+  /// ROS communication.
+  rclcpp_lifecycle::LifecyclePublisher<mocap_msgs::msg::Markers>::SharedPtr mocap_markers_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<mocap_msgs::msg::RigidBody>::SharedPtr mocap_rigid_body_pub_;
   int frame_number_{0};
 };
+
+GazeboRosMocapPrivate::GazeboRosMocapPrivate()
+: ControlledLifecycleNode("gazebo_control")
+{
+  trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+}
+
+
+CallbackReturnT
+GazeboRosMocapPrivate::on_configure(const rclcpp_lifecycle::State & state)
+{
+  mocap_markers_pub_ = create_publisher<mocap_msgs::msg::Markers>(
+    "markers", rclcpp::QoS(1000));
+  mocap_rigid_body_pub_ = create_publisher<mocap_msgs::msg::RigidBody>(
+    "rigid_bodies", rclcpp::QoS(1000));
+
+  return ControlledLifecycleNode::on_configure(state);
+}
+
+CallbackReturnT
+GazeboRosMocapPrivate::on_activate(const rclcpp_lifecycle::State & state)
+{
+  (void)state;
+
+  mocap_markers_pub_->on_activate();
+  mocap_rigid_body_pub_->on_activate();
+
+  return ControlledLifecycleNode::on_activate(state);
+}
+
+CallbackReturnT
+GazeboRosMocapPrivate::on_deactivate(const rclcpp_lifecycle::State & state)
+{
+  (void)state;
+
+  mocap_markers_pub_->on_deactivate();
+  mocap_rigid_body_pub_->on_deactivate();
+
+  return ControlledLifecycleNode::on_deactivate(state);
+}
+
+void
+GazeboRosMocapPrivate::control_start(const mocap_control_msgs::msg::Control::SharedPtr msg)
+{
+  RCLCPP_INFO(get_logger(), "Starting mocap gazebo");
+}
+
+void
+GazeboRosMocapPrivate::control_stop(const mocap_control_msgs::msg::Control::SharedPtr msg)
+{
+  RCLCPP_INFO(get_logger(), "Stopping mocap gazebo");
+}
 
 GazeboRosMocap::GazeboRosMocap()
 : impl_(std::make_unique<GazeboRosMocapPrivate>())
@@ -64,17 +125,10 @@ GazeboRosMocap::~GazeboRosMocap()
 
 void GazeboRosMocap::Load(physics::ModelPtr _parent, sdf::ElementPtr sdf)
 {
-  impl_->ros_node_ = rclcpp::Node::make_shared("gazebo_mocap");
-
   impl_->update_connection_ = gazebo::event::Events::ConnectWorldUpdateBegin(
     std::bind(&GazeboRosMocap::OnUpdate, this));
 
-  impl_->mocap_markers_pub_ = impl_->ros_node_->create_publisher<mocap_msgs::msg::Markers>(
-    "markers", rclcpp::QoS(1000));
-  impl_->mocap_rigid_body_pub_ = impl_->ros_node_->create_publisher<mocap_msgs::msg::RigidBody>(
-    "rigid_bodies", rclcpp::QoS(1000));
-
-  auto logger = impl_->ros_node_->get_logger();
+  auto logger = impl_->get_logger();
 
   if (!sdf->HasElement("link_name")) {
     RCLCPP_INFO(
@@ -84,7 +138,6 @@ void GazeboRosMocap::Load(physics::ModelPtr _parent, sdf::ElementPtr sdf)
   } else {
     impl_->link_name_ = sdf->GetElement("link_name")->Get<std::string>();
   }
-
   impl_->world_ = _parent->GetWorld();
   impl_->link_ = boost::dynamic_pointer_cast<physics::Link>(
     impl_->world_->EntityByName(impl_->link_name_));
@@ -94,6 +147,12 @@ void GazeboRosMocap::Load(physics::ModelPtr _parent, sdf::ElementPtr sdf)
 
 void GazeboRosMocap::OnUpdate()
 {
+  rclcpp::spin_some(impl_->get_node_base_interface());
+
+  if (impl_->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+    return;
+  }
+
   ignition::math::v6::Pose3d pose = impl_->link_->WorldPose();
 
   auto & pos = pose.Pos();
@@ -119,7 +178,7 @@ void GazeboRosMocap::OnUpdate()
     m1.translation.z = pos.Z() + 0.03;
 
     mocap_msgs::msg::Markers ms;
-    ms.header.stamp = impl_->ros_node_->now();
+    ms.header.stamp = impl_->now();
     ms.header.frame_id = "mocap";
     ms.frame_number = impl_->frame_number_++;
     ms.markers = {m1, m2, m3};
@@ -130,7 +189,7 @@ void GazeboRosMocap::OnUpdate()
   if (impl_->mocap_rigid_body_pub_->get_subscription_count() > 0) {
     mocap_msgs::msg::RigidBody rb;
     rb.index = 1;
-    rb.header.stamp = impl_->ros_node_->now();
+    rb.header.stamp = impl_->now();
     rb.header.frame_id = "mocap";
     rb.frame_number = impl_->frame_number_++;
     rb.pose.position.x = pos.X();


### PR DESCRIPTION
Hi all,

This PR contains the integration of the driver with `mocap_control`. Basically, all mocap drivers inherit from `mocap_control::ControlledLifecycleNode`, which let us monitor and control apps like `mocap_control`.

Video demo:

[![](https://img.youtube.com/vi/i9U_T0Ti6Oo/0.jpg)](https://www.youtube.com/watch?v=i9U_T0Ti6Oo&feature=youtu.be "Click to play on You Tube")

I hope you like it!!

**Note:** It is normal that the checks fail now. Ther are some dependencies in CI to fix 