### PR TITLE
New features: you can add several rigid bodies, several markers and create new rigid_bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package provides you with a gazebo plugin that allows you to simulate the u
 
 Add in your robot model the following, as done in [This sample model](https://github.com/MOCAP4ROS2-Project/mocap4ros2_gazebo/blob/main/models/waffle.model):
 
-```
+```xml
     <link name="base_mocap">
         <pose>"0 0 0.577 0 0 0</pose>
         <inertial>
@@ -33,22 +33,37 @@ Add in your robot model the following, as done in [This sample model](https://gi
     <gazebo>
     <plugin name="gazebo_ros_mocap" filename="libgazebo_ros_mocap.so">
       <model_name>robot</model_name>
-      <link_name>base_footprint</link_name>
+      <rigid_link>base_footprint</rigid_link>
     </plugin>
     </gazebo>
+```
+
+If what you want is to add markers, you can do so by adding the following line in your plugin. For this case, we would add a marker in base_footprint:
+```xml
+<plugin name="gazebo_ros_mocap" filename="libgazebo_ros_mocap.so">
+    <model_name>robot</model_name>
+    <marker_link>base_link</marker_link>
+</plugin>
+ ```
+
+And if you have 3 or more markers within your environment, you can create new rigid_bodies from them. To do this, you have to choose the orientation through a link and add the index of the markers you want to add.
+```bash
+ros2 service call /create_rigid_body mocap4r2_msgs/srv/CreateRigidBody 'rigid_body_name: '\'new_rigid''\''
+link_parent: '\'base_link''\''
+markers: [1, 2, 5, 8]'
 ```
 
 ## Run the sample
 
 To see it in action, just type:
 
-```
+```bash
 ros2 launch gazebo_mocap4r2_plugin tb3_simulation_launch.py
 ```
 
 Open gzclient in other terminal:
 
-```
+```bash
 gzclient
 ```
 

--- a/models/waffle.model
+++ b/models/waffle.model
@@ -111,7 +111,7 @@
           <mass>0.125</mass>
         </inertial>
 
-        <collision name="mocap_sensor_collision">
+        <!-- <collision name="mocap_sensor_collision">
           <pose>-0.052 0 0.160 0 0 0</pose>
           <geometry>
             <cylinder>
@@ -119,9 +119,9 @@
               <length>0.055</length>
             </cylinder>
           </geometry>
-        </collision>
+        </collision> -->
 
-        <visual name="mocap_sensor_visual">
+        <!-- <visual name="mocap_sensor_visual">
           <pose>-0.064 0 0.141 0 0 0</pose>
           <geometry>
             <mesh>
@@ -129,7 +129,7 @@
               <scale>0.001 0.001 0.001</scale>
             </mesh>
           </geometry>
-        </visual>
+        </visual> -->
       </link>
 
       <link name="base_scan">
@@ -557,13 +557,10 @@
       </plugin>
 
       <plugin name="gazebo_ros_mocap" filename="libgazebo_ros_mocap.so">
-        <link_name>base_mocap</link_name>
-        <!--ros>
-            <remapping>~/out:=joint_states</remapping>
-        </ros>
-        <update_rate>30</update_rate>
-        <joint_name>wheel_left_joint</joint_name>
-        <joint_name>wheel_right_joint</joint_name-->
+        <rigid_link>base_link</rigid_link>
+        <rigid_link>base_mocap</rigid_link>
+        <marker_link>camera_link</marker_link>
+        <rigid_link>base_footprint</rigid_link>
       </plugin>
     </model>
 </sdf>

--- a/src/gazebo_ros_mocap.cpp
+++ b/src/gazebo_ros_mocap.cpp
@@ -207,7 +207,6 @@ void GazeboRosMocap::Load(physics::ModelPtr _parent, sdf::ElementPtr sdf)
     }
   }
 
-  // Verificar si todos los enlaces fueron encontrados
   for (const auto & link_name : impl_->rigid_link_names_) {
     if (std::find_if(impl_->rigid_links_.begin(), impl_->rigid_links_.end(),
                      [&](const physics::LinkPtr & link) { return link->GetName() == link_name; }) == impl_->rigid_links_.end()) {
@@ -231,86 +230,62 @@ void GazeboRosMocap::OnUpdate()
     return;
   }
 
+  mocap4r2_msgs::msg::Markers ms;
+  ms.header.stamp = impl_->now();
+  ms.frame_number = impl_->frame_number_;
+  ms.header.frame_id = "map";
+
+  mocap4r2_msgs::msg::RigidBodies rbs;
+  rbs.header.stamp = impl_->now();
+  rbs.frame_number = impl_->frame_number_;
+  rbs.header.frame_id = "map";
+  
+  impl_->frame_number_;
+  int index = 1;
+  
   for (const auto & link : impl_->rigid_links_) {
     ignition::math::v6::Pose3d pose = link->WorldPose();
 
     auto & pos = pose.Pos();
     auto & rot = pose.Rot();
 
-    if (impl_->mocap_markers_pub_->get_subscription_count() > 0) {
-      mocap4r2_msgs::msg::Marker m1;
-      m1.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
-      m1.marker_index = 1;
-      m1.translation.x = pos.X();
-      m1.translation.y = pos.Y();
-      m1.translation.z = pos.Z() + 0.05;
+    mocap4r2_msgs::msg::Marker m1;
+    m1.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
+    m1.marker_index = index++;
+    m1.translation.x = pos.X();
+    m1.translation.y = pos.Y();
+    m1.translation.z = pos.Z() + 0.05;
 
-      mocap4r2_msgs::msg::Marker m2;
-      m2.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
-      m2.marker_index = 2;
-      m2.translation.x = pos.X() + 0.02;
-      m2.translation.y = pos.Y();
-      m2.translation.z = pos.Z() + 0.03;
+    mocap4r2_msgs::msg::Marker m2;
+    m2.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
+    m2.marker_index = index++;
+    m2.translation.x = pos.X() + 0.02;
+    m2.translation.y = pos.Y();
+    m2.translation.z = pos.Z() + 0.03;
 
-      mocap4r2_msgs::msg::Marker m3;
-      m3.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
-      m3.marker_index = 3;
-      m3.translation.x = pos.X();
-      m3.translation.y = pos.Y() + 0.015;
-      m3.translation.z = pos.Z() + 0.03;
+    mocap4r2_msgs::msg::Marker m3;
+    m3.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
+    m3.marker_index = index++;
+    m3.translation.x = pos.X();
+    m3.translation.y = pos.Y() + 0.015;
+    m3.translation.z = pos.Z() + 0.03;
 
-      mocap4r2_msgs::msg::Markers ms;
-      ms.header.stamp = impl_->now();
-      ms.header.frame_id = "map";
-      ms.frame_number = impl_->frame_number_++;
-      ms.markers = {m1, m2, m3};
+    mocap4r2_msgs::msg::RigidBody rb;
+    rb.rigid_body_name = "rigid_body_" + link->GetName();
+    rb.pose.position.x = pos.X();
+    rb.pose.position.y = pos.Y();
+    rb.pose.position.z = pos.Z();
+    rb.pose.orientation.x = rot.X();
+    rb.pose.orientation.y = rot.Y();
+    rb.pose.orientation.z = rot.Z();
+    rb.pose.orientation.w = rot.W();
 
-      impl_->mocap_markers_pub_->publish(ms);
-      rclcpp::spin_some(impl_->get_node_base_interface());
-    }
-
-    if (impl_->mocap_rigid_body_pub_->get_subscription_count() > 0) {
-      mocap4r2_msgs::msg::RigidBody rb1;
-      rb1.rigid_body_name = "rigid_body_" + link->GetName();
-      rb1.pose.position.x = pos.X();
-      rb1.pose.position.y = pos.Y();
-      rb1.pose.position.z = pos.Z();
-      rb1.pose.orientation.x = rot.X();
-      rb1.pose.orientation.y = rot.Y();
-      rb1.pose.orientation.z = rot.Z();
-      rb1.pose.orientation.w = rot.W();
-
-      mocap4r2_msgs::msg::Marker m1;
-      m1.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
-      m1.marker_index = 1;
-      m1.translation.x = pos.X();
-      m1.translation.y = pos.Y();
-      m1.translation.z = pos.Z() + 0.05;
-
-      mocap4r2_msgs::msg::Marker m2;
-      m2.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
-      m2.marker_index = 2;
-      m2.translation.x = pos.X() + 0.02;
-      m2.translation.y = pos.Y();
-      m2.translation.z = pos.Z() + 0.03;
-
-      mocap4r2_msgs::msg::Marker m3;
-      m3.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
-      m3.marker_index = 3;
-      m3.translation.x = pos.X();
-      m3.translation.y = pos.Y() + 0.015;
-      m3.translation.z = pos.Z() + 0.03;
-
-      rb1.markers = {m1, m2, m3};
-
-      mocap4r2_msgs::msg::RigidBodies rbs;
-      rbs.header.stamp = impl_->now();
-      rbs.header.frame_id = "map";
-      rbs.rigidbodies = {rb1};
-
-      impl_->mocap_rigid_body_pub_->publish(rbs);
-      rclcpp::spin_some(impl_->get_node_base_interface());
-    }
+    rb.markers = {m1, m2, m3};
+    
+    ms.markers.push_back(m1);
+    ms.markers.push_back(m2);
+    ms.markers.push_back(m3);
+    rbs.rigidbodies.push_back(rb);
   }
 
   for (const auto & link : impl_->marker_links_) {
@@ -318,23 +293,22 @@ void GazeboRosMocap::OnUpdate()
 
     auto & pos = pose.Pos();
 
-    if (impl_->mocap_markers_pub_->get_subscription_count() > 0) {
-      mocap4r2_msgs::msg::Marker m1;
-      m1.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
-      m1.marker_index = 1;
-      m1.translation.x = pos.X();
-      m1.translation.y = pos.Y();
-      m1.translation.z = pos.Z();
+    mocap4r2_msgs::msg::Marker m1;
+    m1.id_type = mocap4r2_msgs::msg::Marker::USE_INDEX;
+    m1.marker_index = index++;
+    m1.translation.x = pos.X();
+    m1.translation.y = pos.Y();
+    m1.translation.z = pos.Z();
 
-      mocap4r2_msgs::msg::Markers ms;
-      ms.header.stamp = impl_->now();
-      ms.header.frame_id = "map";
-      ms.frame_number = impl_->frame_number_++;
-      ms.markers = {m1};
+    ms.markers.push_back(m1);
+  }
 
-      impl_->mocap_markers_pub_->publish(ms);
-      rclcpp::spin_some(impl_->get_node_base_interface());
-    }
+  if (impl_->mocap_markers_pub_->get_subscription_count() > 0) {
+    impl_->mocap_markers_pub_->publish(ms);
+  }
+
+  if (impl_->mocap_rigid_body_pub_->get_subscription_count() > 0) {
+    impl_->mocap_rigid_body_pub_->publish(rbs);
   }
 }
 


### PR DESCRIPTION
Hi!!

As the title says, I have added the following:
- Renamed link_name to rigid_link to add a rigid_body.
- If you add multiple rigid_links, multiple rigid_bodies are created in different links.
- You can add marker_link in your plugin to add a marker on that link.
- Added service to group several markers in a rigid_body. The centroid of the polygon they form will be taken and the orientation will be given by the link that is specified.

For the CI to work and the package to be used, you first need to accept this [PR](https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs/pull/13)

In the future, I would like to add an rqt plugin that can add new rigid, markers, and group markers in rigis, as well as being able to do it from mocap4r2cli.